### PR TITLE
Update package.json (Fixes #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "scripts": {
     "test": "tree-sitter test"
-  }
+  },
+  "tree-sitter": [
+      {"file-types": ["sqlrest"]}
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "test": "tree-sitter test"
   },
   "tree-sitter": [
-      {"file-types": ["sqlrest"]}
+    {
+      "file-types": [
+        "sqlrest"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
This should fix the issue. I was able to generate the parser with the updated `package.json` using `tree-sitter` v0.22.1. I noticed that `tree-sitter` also makes some additional changes to `package.json` when generating the parser:

> Replacing nan dependency with node-addon-api in package.json
> Adding node-gyp-build dependency to package.json
> Adding prebuildify devDependency to package.json
> Adding an install script to package.json
> Adding a prebuildify script to package.json
> Adding peerDependencies to package.json
> Adding types to package.json
> Adding files to package.json

The resulting `package.json` has the following content:

```JSON
{
  "name": "tree-sitter-sqlrest",
  "version": "0.0.1",
  "description": "sqlrest grammar for tree-sitter",
  "main": "bindings/node",
  "types": "bindings/node",
  "keywords": [
    "parsing",
    "incremental"
  ],
  "files": [
    "grammar.js",
    "binding.gyp",
    "prebuilds/**",
    "bindings/node/*",
    "queries/*",
    "src/**"
  ],
  "dependencies": {
    "node-addon-api": "^7.1.0",
    "node-gyp-build": "^4.8.0"
  },
  "peerDependencies": {
    "tree-sitter": "^0.21.0"
  },
  "peerDependenciesMeta": {
    "tree_sitter": {
      "optional": true
    }
  },
  "devDependencies": {
    "tree-sitter-cli": "^0.20.6",
    "prebuildify": "^6.0.0"
  },
  "scripts": {
    "test": "tree-sitter test",
    "install": "node-gyp-build",
    "prebuildify": "prebuildify --napi --strip"
  },
  "tree-sitter": [
    {
      "file-types": [
        "sqlrest"
      ]
    }
  ]
}
```
I don't know for sure which `package.json` is preferable. Maybe it doesn't matter since the changes are auto-generated anyway.